### PR TITLE
Install python-six before installing Keystone

### DIFF
--- a/playbooks/roles/http/tasks/main.yaml
+++ b/playbooks/roles/http/tasks/main.yaml
@@ -114,14 +114,11 @@
     mode=0400
   notify: restart apache2
 
-# this is a workaround for older pip distributions
-- name: upgrade to latest pip / setuptools
+# this is a workaround for installing on Debian Wheezy
+- name: install python-six
   pip:
-    name={{ item }}
+    name=six
     state=latest
-  with_items:
-    - pip
-    - setuptools
 
 - name: install keystone
   shell: cd /opt/keystone && python setup.py install


### PR DESCRIPTION
There seems to be an issue with running the current keystone-deploy playbook on
debian wheezy. Installing python-six prior to installing keystone from source
seems to clear up the issue. This can be reverted/removed once fixed upstream.
