### PR TITLE
Use oslo.middleware in paste.ini

### DIFF
--- a/playbooks/roles/http/templates/paste.ini
+++ b/playbooks/roles/http/templates/paste.ini
@@ -47,7 +47,7 @@ paste.filter_factory = keystone.contrib.revoke.routers:RevokeExtension.factory
 paste.filter_factory = keystone.middleware:NormalizingFilter.factory
 
 [filter:sizelimit]
-paste.filter_factory = keystone.middleware:RequestBodySizeLimiter.factory
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
 
 [app:public_service]
 paste.app_factory = keystone.service:public_app_factory


### PR DESCRIPTION
This commit changes the paste.ini to use oslo.middleware for the sizelimit
filter versus the deprecated version from keystone.middleware.

fixes #4
