### PR TITLE
Install project dependencies

### DIFF
--- a/playbooks/roles/apache2/tasks/main.yaml
+++ b/playbooks/roles/apache2/tasks/main.yaml
@@ -31,7 +31,8 @@
 
 - name: enable mpm_prefork
   command: a2enmod mpm_prefork
-  when: not mpm_prefork.stat.exists
+  when: not mpm_prefork.stat.exists and
+      (ansible_lsb.id == "Ubuntu" and ansible_lsb.release == "14.04")
 
 - name: remove the default virtual host
   file:

--- a/playbooks/roles/echo/templates/apache/echo.vhost
+++ b/playbooks/roles/echo/templates/apache/echo.vhost
@@ -5,9 +5,11 @@
 ServerLimit {{ virtual_hosts * process_count }}
 MaxClients {{ virtual_hosts * process_count }}
 StartServers {{ virtual_hosts * process_count }}
+{% if apache24|success -%}
 MinSpareServers {{ process_count }}
 MaxSpareServers {{ process_count }}
 MaxRequestWorkers {{ virtual_hosts * process_count * thread_count }}
+{%- endif %}
 
 <VirtualHost *:80>
     WSGIScriptAlias / /var/echo/echo.py

--- a/playbooks/roles/keystone/tasks/main.yaml
+++ b/playbooks/roles/keystone/tasks/main.yaml
@@ -75,6 +75,13 @@
     - keystone
     - python-keystoneclient
 
+- name: install project requirements
+  pip:
+    requirements=/opt/{{ item }}/requirements.txt
+  with_items:
+    - keystone
+    - python-keystoneclient
+
 - name: run database migrations
   command: keystone-manage db_sync
 

--- a/playbooks/roles/keystone/templates/apache/keystone.vhost
+++ b/playbooks/roles/keystone/templates/apache/keystone.vhost
@@ -5,9 +5,11 @@
 ServerLimit {{ virtual_hosts * process_count }}
 MaxClients {{ virtual_hosts * process_count }}
 StartServers {{ virtual_hosts * process_count }}
+{% if apache24|success -%}
 MinSpareServers {{ process_count }}
 MaxSpareServers {{ process_count }}
 MaxRequestWorkers {{ virtual_hosts * process_count * thread_count }}
+{%- endif %}
 
 Listen 5000
 Listen 35357


### PR DESCRIPTION
When using the latest master of keystone-deploy, an error is thrown when
ansible attempts to sync the keystone database (keystone-manage db_sync). The
command errors out saying there is no oslo_config module, even though
oslo.config is listed as a dependency in keystone's requirements.txt file. I
believe this should be done when the project is installed  using `python
setup.py install` prior to running the migration but I'm not sure why
oslo_config isn't found.

This commit just adds an ansible play to manually install the project
requirements.txt files using pip before the migration is run.
